### PR TITLE
Datetime OutOfRange issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='tap-mongodb',
       py_modules=['tap_mongodb'],
       install_requires=[
           'singer-python==5.8.0',
-          'pymongo==3.12.3',
+          'pymongo==4.3.2',
           'tzlocal==2.0.0',
           'terminaltables==3.1.0',
       ],

--- a/tap_mongodb/__init__.py
+++ b/tap_mongodb/__init__.py
@@ -5,8 +5,9 @@ import ssl
 import sys
 import time
 import pymongo
+import datetime
 from bson import timestamp
-
+from bson.codec_options import DatetimeConversion
 import singer
 from singer import metadata, metrics, utils
 
@@ -14,7 +15,6 @@ import tap_mongodb.sync_strategies.common as common
 import tap_mongodb.sync_strategies.full_table as full_table
 import tap_mongodb.sync_strategies.oplog as oplog
 import tap_mongodb.sync_strategies.incremental as incremental
-
 
 LOGGER = singer.get_logger()
 
@@ -409,7 +409,7 @@ def main_impl():
 
     uri = build_mongodb_uri(connection_params)
     
-    client = pymongo.MongoClient(uri)
+    client = pymongo.MongoClient(uri, datetime_conversion=DatetimeConversion.DATETIME_CLAMP)
 
     LOGGER.info('Connected to MongoDB host: %s, version: %s',
                 config['host'],


### PR DESCRIPTION
- Upgrading version of Pymongo to version 4.3.2 to solve issues related with datetime overflow as mentioned in the following thread
https://pymongo.readthedocs.io/en/stable/faq.html#why-do-i-get-overflowerror-decoding-dates-stored-by-another-language-s-driver

There are some configurations, but the one that better satisfies our requirements is the DatetimeConversion.DATETIME_CLAMP because if a value is an OutOfRange date, the value is truncated to the MINYEAR value...
```python
x = encode({"x": datetime(1970, 1, 1)})
y = encode({"x": DatetimeMS(-(2**62))})
codec_auto = CodecOptions(datetime_conversion=DatetimeConversion.DATETIME_AUTO)
decode(x, codec_options=codec_auto)
{'x': datetime.datetime(1970, 1, 1, 0, 0)}
decode(y, codec_options=codec_auto)
{'x': DatetimeMS(-4611686018427387904)}
```
For more information: https://pymongo.readthedocs.io/en/stable/examples/datetimes.html#handling-out-of-range-datetimes
