### PR TITLE
UPDATE: allowing usage of disk when memory limit is exceeded

### DIFF
--- a/tap_mongodb/sync_strategies/incremental.py
+++ b/tap_mongodb/sync_strategies/incremental.py
@@ -86,7 +86,9 @@ def sync_collection(client, stream, state, projection):
     schema = {"type": "object", "properties": {}}
     with collection.find(find_filter,
                          projection,
-                         sort=[(replication_key_name, pymongo.ASCENDING)]) as cursor:
+                         sort=[(replication_key_name, pymongo.ASCENDING)],
+                         allow_disk_usage=True
+                    ) as cursor:
         rows_saved = 0
         time_extracted = utils.now()
         start_time = time.time()

--- a/tap_mongodb/sync_strategies/incremental.py
+++ b/tap_mongodb/sync_strategies/incremental.py
@@ -87,7 +87,7 @@ def sync_collection(client, stream, state, projection):
     with collection.find(find_filter,
                          projection,
                          sort=[(replication_key_name, pymongo.ASCENDING)],
-                         allow_disk_usage=True
+                         allow_disk_use=True
                     ) as cursor:
         rows_saved = 0
         time_extracted = utils.now()


### PR DESCRIPTION
Why this change is required?

When an operation exceeds the memory limit for MongoDB of (100mb), an error is raised if allow_disk_usage=False.

The error is the following:
```python
raise OperationFailure(errmsg, code, response, max_wire_version)
pymongo.errors.OperationFailure: Executor error during find command :: caused by ::
Sort exceeded memory limit of 104857600 bytes, but did not opt in to external sorting.,
full error: {
     'ok': 0.0,
      'errmsg': 'Executor error during find command :: caused by :: Sort exceeded memory limit of 104857600 bytes, but did not opt in to external sorting.',
      'code': 292,
      'codeName': 'QueryExceededMemoryLimitNoDiskUseAllowed',
      '$clusterTime': {'clusterTime': Timestamp(1709482622, 1),
      'signature': {'hash': b'\xf8/\xb2q\xdb\x8b7z\x87\xecKQ6\x03\x8e\xe8\x83\x83\xe9G', 'keyId': 7286832237264240642}},
      'operationTime': Timestamp(1709482622, 1)
}
````
According to pymongo documentation:
allow_disk_use (optional): if True, MongoDB may use temporary disk files to store data exceeding the system memory limit while processing a blocking sort operation. The option has no effect if MongoDB can satisfy the specified sort using an index, or if the blocking sort requires less memory than the 100 MiB limit. This option is only supported on MongoDB 4.4 and above.

Why this change was necessary?
To allow incremental pipelines when the tables are huge.

How does it address the problem?
Allowing disk usage

Related tickets or issues: [TECN-7509]

[TECN-7509]: https://dadosfera.atlassian.net/browse/TECN-7509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ